### PR TITLE
feat: option to reference variables in ctk configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chaostoolkit-terraform
+# ChaosToolkit Terraform
 
 A [Chaos Toolkit](https://chaostoolkit.org/) driver to extend chaos experiments with [Terraform](https://www.terraform.io/)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ controls:
         retain: true
 ```
 
-**Configuration using Ctk parameters**
+**Configuration using Chaos Toolkit parameters**
 ```yaml
 configuration:
 # parameters prefixed with `tf_conf__` will configure chaosterraform driver
@@ -90,16 +90,29 @@ controls:
 | **retain** | Do not run `terraform destroy` at the end of the experiment to retain resources, defaults to `false` |
 | **chdir** | Instruct Terraform to change its working directory before running subcommands |
 
-## Set Terraform Input Variables
+## Provide Input Variables for Terraform
 
-You can override input variables defined in the Terraform module from within the experiment using
-Chaos Toolkit configuration parameters prefixed by `tf__`:
+You can override input variables defined in the Terraform module from within the experiment using the `variables`
+argument for the control:
+
+```yaml
+controls:
+  - name: "Deploy Terraform module"
+    provider:
+      type: python
+      module: chaosterraform.control
+      arguments:
+        variables:
+          vpc_id: "vpc-0000000000"
+          number_of_azs: 2
+```
+
+Alternatively, you can supply input variables from Chaos Toolkit configuration by referencing a parameter name
+already defined in Chaos Toolkit configuration:
 
 ```yaml
 configuration:
-# parameters prefixed with `tf__` will set terraform input variables for the module
-  tf__vpc_id: "vpc-0000000000"
-  tf__number_of_azs: 2
+  env_name: "live"
   ...
 
 controls:
@@ -107,8 +120,11 @@ controls:
     provider:
       type: python
       module: chaosterraform.control
+      arguments:
+        variables:
+          environment:
+            name: "env_name"
 ```
-
 
 ## Use Terraform Outputs In Chaos Experiments
 

--- a/chaosterraform/control.py
+++ b/chaosterraform/control.py
@@ -4,7 +4,7 @@ Terraform control module
 This module allows Chaos Toolkit users to create infrastructure resources using Terraform scripts
 for the experiment execution.
 """
-from typing import Any, List, Dict
+from typing import Any, Dict, List
 
 from chaoslib.exceptions import InterruptExecution
 from chaoslib.types import Configuration, Experiment, Journal, Secrets, Settings
@@ -38,6 +38,10 @@ def configure_control(
         retain created resources at the end of the experiment
     chdir: str
         change the Terraform working directory
+    variables: List
+        input variables configuration for Terraform
+    outputs: Dict
+       configuration to map Terraform outputs to ChaosToolkit variables
 
     Raises
     ------
@@ -60,7 +64,7 @@ def configure_control(
         str(params.get("retain")),
     )
 
-    driver = Terraform(**params, args=tf_vars, outputs=outputs)
+    driver = Terraform(**params, args=tf_vars, output_config=outputs)
     driver.terraform_init()
 
 
@@ -88,8 +92,8 @@ def before_experiment_control(
     for key, value in driver.output().items():
         logger.info("Terraform: reading configuration value for [%s]", key)
         configuration[f"{EXPORT_VAR_PREFIX}{key}"] = value.get("value")
-        if key in driver.outputs:
-            export_name = driver.outputs[key]
+        if key in driver.output_config:
+            export_name = driver.output_config[key]
             configuration[export_name] = value.get("value")
 
 

--- a/chaosterraform/control.py
+++ b/chaosterraform/control.py
@@ -4,12 +4,14 @@ Terraform control module
 This module allows Chaos Toolkit users to create infrastructure resources using Terraform scripts
 for the experiment execution.
 """
+from typing import Any, List
+
+from chaoslib.exceptions import InterruptExecution
 from chaoslib.types import Configuration, Experiment, Journal, Secrets, Settings
 from logzero import logger
 
 from .driver import Terraform
 
-VAR_NAME_PREFIX = "tf__"
 CONFIG_PREFIX = "tf_conf__"
 EXPORT_VAR_PREFIX = "tf_out__"
 
@@ -18,6 +20,7 @@ def configure_control(
     silent: bool = True,
     retain: bool = False,
     chdir: str = None,
+    variables: List = None,
     configuration: Configuration = None,
     secrets: Secrets = None,
     settings: Settings = None,
@@ -42,14 +45,9 @@ def configure_control(
     """
     # pylint: disable=unused-argument
     tf_vars = {}
-    if configuration:
-        for key, value in configuration.items():
-            if key.startswith(VAR_NAME_PREFIX):
-                tf_key = key.replace(VAR_NAME_PREFIX, "")
-                tf_vars[tf_key] = value
-
-    for key, _ in tf_vars.items():
-        configuration.pop(f"{VAR_NAME_PREFIX}{key}")
+    if variables:
+        for key, value in variables.items():
+            tf_vars[key] = _resolve_variable(configuration, key, value)
 
     params = {
         "retain": bool(configuration.get(f"{CONFIG_PREFIX}retain", retain)),
@@ -111,3 +109,17 @@ def after_experiment_control(
         driver.destroy()
     else:
         logger.info("Terraform: stack resources will be retained after experiment completion.")
+
+
+def _resolve_variable(configuration, key, value) -> Any:
+    if isinstance(value, dict):
+        if "name" not in value:
+            raise InterruptExecution(f"Terraform: parameter {key} should specify either a value or a 'name' key.")
+
+        parameter_name = value["name"]
+        if parameter_name not in configuration:
+            raise InterruptExecution(f"Terraform: could not resolve value for variable {key} in configuration")
+
+        return configuration[parameter_name]
+
+    return value

--- a/chaosterraform/driver.py
+++ b/chaosterraform/driver.py
@@ -46,6 +46,8 @@ class Terraform:
         is interrupted with an InterruptExecution exception
     args: Dict
         Terraform variables overrides
+    output_config: Dict
+        Configuration to map Terraform output to configuration variables
 
     Raises
     ------
@@ -59,14 +61,14 @@ class Terraform:
         silent: bool = False,
         chdir: str = None,
         args: Dict = None,
-        outputs: Dict = None,
+        output_config: Dict = None,
     ):
         super().__init__()
         self.retain = retain
         self.silent = silent
         self.chdir = chdir
         self.args = args or {}
-        self.outputs = outputs or {}
+        self.output_config = output_config or {}
 
     @property
     def _terraform(self):

--- a/chaosterraform/driver.py
+++ b/chaosterraform/driver.py
@@ -59,12 +59,14 @@ class Terraform:
         silent: bool = False,
         chdir: str = None,
         args: Dict = None,
+        outputs: Dict = None,
     ):
         super().__init__()
         self.retain = retain
         self.silent = silent
         self.chdir = chdir
         self.args = args or {}
+        self.outputs = outputs or {}
 
     @property
     def _terraform(self):

--- a/examples/experiment.yaml
+++ b/examples/experiment.yaml
@@ -3,7 +3,7 @@ description: Use chaosterraform to deploy terraform code
 
 configuration:
   # Override Terraform input variable `restart` when applying the stack
-  tf__restart: "always"
+  restart_policy: "always"
 
 controls:
   - name: chaosterraform
@@ -14,6 +14,11 @@ controls:
         # For demonstration, ask chaosterraform to retain the created
         # resources after the experiment
         retain: true
+        silent: true
+        variables:
+          restart:
+            name: restart_policy
+          local_port: 8080
 
 steady-state-hypothesis:
   title: "check-service-online"

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -8,7 +8,9 @@ from chaosterraform import control
 def test_configure_control_with_parameters(mocked_driver):
     control.configure_control(silent=False, retain=True, chdir="../testfolder/one", configuration={})
 
-    mocked_driver.assert_called_once_with(silent=False, retain=True, chdir="../testfolder/one", args={})
+    mocked_driver.assert_called_once_with(
+        silent=False, retain=True, chdir="../testfolder/one", args={}, output_config=None
+    )
     mock_instance = mocked_driver.return_value
     mock_instance.terraform_init.assert_called()
 
@@ -37,7 +39,9 @@ def test_configure_control_with_terraform_variables(mocked_driver):
         "four": "direct-value-assignment",
     }
 
-    mocked_driver.assert_called_once_with(silent=True, retain=False, chdir=None, args=expected_variables)
+    mocked_driver.assert_called_once_with(
+        silent=True, retain=False, chdir=None, args=expected_variables, output_config=None
+    )
 
 
 @patch("chaosterraform.control.Terraform", autospec=True)
@@ -81,7 +85,9 @@ def test_configure_control_configuration_override(mocked_driver):
 
     control.configure_control(silent=True, retain=False, chdir="some/folder", configuration=configuration)
 
-    mocked_driver.assert_called_once_with(silent=False, retain=True, chdir="my/other/folder/path", args={})
+    mocked_driver.assert_called_once_with(
+        silent=False, retain=True, chdir="my/other/folder/path", args={}, output_config=None
+    )
 
 
 @patch("chaosterraform.control.Terraform", autospec=True)


### PR DESCRIPTION
Variable overrides for the terraform template can now be configured either directly in the control or by referencing an exising chaos toolkit configuration. This will reduce the amount of duplication in case we need to use the same variable in both the experiment and the terraform template.